### PR TITLE
Add research page quick navigation and quote styling

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -349,7 +349,9 @@ main {
 }
 
 .page-heading {
-  margin-bottom: 2.5rem;
+  display: grid;
+  gap: 1.5rem;
+  margin-bottom: 3rem;
 }
 
 .page-heading h1 {
@@ -362,6 +364,88 @@ main {
   margin: 0;
   max-width: 680px;
   color: var(--muted);
+}
+
+.research-quote {
+  margin: 0;
+  padding: 1.5rem 1.75rem;
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, rgba(138, 180, 255, 0.18), rgba(74, 144, 255, 0.08));
+  border: 1px solid rgba(138, 180, 255, 0.28);
+  box-shadow: 0 18px 40px rgba(10, 20, 40, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.research-quote::before {
+  content: "\201C";
+  position: absolute;
+  top: -10px;
+  left: 16px;
+  font-size: 6rem;
+  color: rgba(138, 180, 255, 0.16);
+  font-family: "Georgia", "Times New Roman", serif;
+}
+
+.research-quote p {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  position: relative;
+  z-index: 1;
+}
+
+.research-quote footer {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+  font-style: italic;
+  position: relative;
+  z-index: 1;
+}
+
+.research-quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.quick-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(12, 18, 32, 0.75);
+  border: 1px solid rgba(138, 180, 255, 0.32);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.quick-link:hover,
+.quick-link:focus {
+  background-color: var(--primary);
+  border-color: var(--primary);
+  color: #050911;
+  transform: translateY(-2px);
+}
+
+@media (max-width: 600px) {
+  .page-heading {
+    text-align: center;
+  }
+
+  .research-quote::before {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .research-quick-links {
+    justify-content: center;
+  }
 }
 
 .card-grid {

--- a/research.html
+++ b/research.html
@@ -41,10 +41,18 @@
     <main>
       <div class="page-heading">
         <h1>Research</h1>
-        <p>
-          I investigate physics-informed machine learning for wireless communication, blending electromagnetic theory with
-          data-driven models to create robust 6G systems.
-        </p>
+        <blockquote class="research-quote">
+          <p>
+            “The knowledge of anything, since all things have causes, is not acquired or complete unless it is known by its
+            causes.”
+          </p>
+          <footer>— Ibn Sina</footer>
+        </blockquote>
+        <div class="research-quick-links" role="navigation" aria-label="Research section shortcuts">
+          <a class="quick-link" href="#current-research">Current Research</a>
+          <a class="quick-link" href="#past-research">Past Research</a>
+          <a class="quick-link" href="#collaborators">Research Collaborators</a>
+        </div>
       </div>
 
       <section class="section">
@@ -54,7 +62,7 @@
         </p>
       </section>
 
-      <section class="section">
+      <section class="section" id="current-research">
         <h2>Current research</h2>
         <figure class="feature-figure">
           <img
@@ -90,7 +98,7 @@
         </div>
       </section>
 
-      <section class="section">
+      <section class="section" id="past-research">
         <h2>Past research</h2>
         <figure class="feature-figure">
           <img


### PR DESCRIPTION
## Summary
- add quick navigation buttons to key research sections
- replace the introductory research text with a styled Ibn Sina quote
- extend research page styles for the new quote and quick links

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed47585b408324ba50daf72de22302