### PR TITLE
Fix homepage biography, metrics, PU-HNO descriptions, milestones and collaborators

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1053,6 +1053,18 @@ li {
   letter-spacing: -0.03em;
 }
 
+.biography-text {
+  max-width: 980px;
+}
+
+.biography-text p {
+  margin-bottom: 0;
+}
+
+.biography-text p + p {
+  margin-top: 1.1rem;
+}
+
 .two-column-text,
 .page-heading--split,
 .showcase-grid,

--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@
           </figure>
           <div class="metric-grid">
             <div class="metric-card">
-              <span class="metric-value">4.0/4.0</span>
-              <span class="metric-label">UIUC first-year GPA</span>
+              <span class="metric-value">4.0 out of 4.0</span>
+              <span class="metric-label">Graduate GPA</span>
             </div>
             <div class="metric-card">
               <span class="metric-value">150+</span>
@@ -76,8 +76,8 @@
               <span class="metric-label">i10-index</span>
             </div>
             <div class="metric-card">
-              <span class="metric-value">2026</span>
-              <span class="metric-label">EWSN accepted paper</span>
+              <span class="metric-value">6</span>
+              <span class="metric-label">h-index</span>
             </div>
           </div>
         </aside>
@@ -86,18 +86,35 @@
       <section class="section section--intro" id="biography">
         <div class="section-kicker">Biography</div>
         <h2>Researcher at the intersection of wireless systems, machine learning, and physical modeling.</h2>
-        <div class="two-column-text">
+        <div class="biography-text">
           <p>
-            I am pursuing my Ph.D. in Computer Science at UIUC, advised by
-            <a href="https://elahe.web.illinois.edu/">Prof. Elahe Soltanaghai</a> in the
-            <a href="https://isens.cs.illinois.edu/">iSens Lab</a>, where I completed my first year with a perfect
-            4.0/4.0 GPA. My current work develops high-fidelity wireless digital twins through neural fields,
-            object-centric neural operators, and physics-informed deep learning for integrated sensing and communication.
+            I received my B.Sc. in Electrical and Electronic Engineering from the
+            <a href="https://www.buet.ac.bd/">Bangladesh University of Engineering and Technology (BUET)</a> in May 2022,
+            with a concentration in signal processing and wireless communications. My undergraduate thesis, under the
+            supervision of
+            <a href="https://researchprofiles.canberra.edu.au/en/persons/md-farhad-hossain">Dr. Farhad Hossain</a>,
+            explored deep learning–based hybrid beamforming for MIMO systems.
           </p>
           <p>
-            In Summer 2026, I joined the InterDigital AI Lab in Los Altos as an ML Research Intern, working on unsupervised
-            physics-based CSI compression and spatiotemporal AI models for AI-native 3GPP/6G channel representations. Before
-            UIUC, I earned an M.Sc. in Electrical Engineering from UT Dallas with a 4.0/4.0 GPA and a B.Sc. in EEE from BUET.
+            After graduation, I worked as a research engineer at the
+            <a href="https://jidpus.buet.ac.bd/">Japan Institute of Disaster Prevention and Urban Safety (BUET-JIDPUS)</a>,
+            where I contributed to the Earthquake Early Warning (EEW) project. In August 2023, I began my M.Sc. in
+            Electrical and Computer Engineering at
+            <a href="https://www.utdallas.edu/">The University of Texas at Dallas</a> under
+            <a href="https://personal.utdallas.edu/~saquib/">Dr. Mohammad Saquib</a>, completing the degree in May 2025
+            with a perfect GPA of 4.0/4.0. My master’s thesis, <em>Real-Time Beamforming and Metasurface Design for
+            Low-Latency 6G Wireless Networks</em>, advanced low-complexity algorithms for massive MIMO and RIS optimization.
+          </p>
+          <p>
+            I am currently pursuing my Ph.D. in Computer Science at the
+            <a href="https://illinois.edu/">University of Illinois Urbana-Champaign (UIUC)</a> as a recipient of the Siebel
+            School Fellowship. I have joined the <a href="https://isens.cs.illinois.edu/">iSens Lab</a> under
+            <a href="https://elahe.web.illinois.edu/">Dr. Elahe Soltanaghai</a>, where my research focuses on
+            physics-informed deep learning for next-generation wireless systems. My work spans trustworthy digital twins,
+            RF propagation modeling, MU-MIMO beamforming, reconfigurable intelligent surfaces, resource allocation, and
+            wireless sensing. I have published in leading journals and conferences, and have been invited to present my
+            research in venues such as the NSF MERIF workshop and the ARAFest. I have been fortunate to collaborate with
+            leading professors, scholars, and researchers from premier institutions, including MIT and UC Berkeley.
           </p>
         </div>
       </section>
@@ -132,10 +149,12 @@
           <article class="showcase-card">
             <div>
               <span class="publication-badge">Submitted · NeurIPS 2026</span>
-              <h3>Hybrid Neural Operators for Wireless Field Modeling</h3>
+              <h3>PU-HNO: Physics-Unrolled Hybrid Neural Operator for Radio Maps</h3>
               <p>
-                This submission investigates neural operators for object-centric wireless fields, targeting scalable
-                generalization across geometry, propagation environments, and downstream wireless tasks.
+                PU-HNO predicts high-fidelity indoor radio maps from low-fidelity ray-tracing outputs and scene priors by
+                progressively capturing reflection, diffraction, and scattering effects. The work shows that, under
+                conditionally unbiased label noise, the model can learn stable propagation structure and outperform noisy
+                finite-ray training labels across image-quality and wireless deployment metrics.
               </p>
             </div>
           </article>
@@ -147,28 +166,28 @@
         <h2>Milestones</h2>
         <ul class="timeline">
           <li>
-            <span class="timeline-date">Summer 2026</span>
-            <span class="timeline-description">Joined the InterDigital AI Lab in Los Altos as an ML Research Intern.</span>
-          </li>
-          <li>
-            <span class="timeline-date">2026</span>
-            <span class="timeline-description"><em>WiNeRF</em> accepted to the 23rd International Conference on Embedded Wireless Systems and Networks (EWSN), Dresden, Germany.</span>
-          </li>
-          <li>
-            <span class="timeline-date">2026</span>
-            <span class="timeline-description"><em>Hybrid Neural Operators for Wireless Field Modeling</em> submitted to NeurIPS 2026.</span>
-          </li>
-          <li>
-            <span class="timeline-date">2025–2026</span>
-            <span class="timeline-description">Completed the first year of the UIUC CS PhD program with a 4.0/4.0 GPA.</span>
-          </li>
-          <li>
-            <span class="timeline-date">2025</span>
+            <span class="timeline-date">June 2026</span>
             <span class="timeline-description"><em>I-NAV</em> accepted to Elsevier's <em>Array</em> journal.</span>
           </li>
           <li>
-            <span class="timeline-date">2026</span>
-            <span class="timeline-description">Reached 150+ Google Scholar citations and an i10-index of 5.</span>
+            <span class="timeline-date">May 2026</span>
+            <span class="timeline-description">Joined InterDigital AI Lab in Los Altos as an ML Research Intern.</span>
+          </li>
+          <li>
+            <span class="timeline-date">May 2026</span>
+            <span class="timeline-description"><em>PU-HNO</em> radio-map prediction paper submitted to NeurIPS 2026.</span>
+          </li>
+          <li>
+            <span class="timeline-date">May 2026</span>
+            <span class="timeline-description">Completed the first year of the UIUC CS PhD program with a 4.0/4.0 GPA.</span>
+          </li>
+          <li>
+            <span class="timeline-date">April 2026</span>
+            <span class="timeline-description">Reached 150+ Google Scholar citations.</span>
+          </li>
+          <li>
+            <span class="timeline-date">March 2026</span>
+            <span class="timeline-description"><em>WiNeRF</em> accepted to the 23rd International Conference on Embedded Wireless Systems and Networks (EWSN), Dresden, Germany.</span>
           </li>
         </ul>
       </section>

--- a/publications.html
+++ b/publications.html
@@ -72,11 +72,12 @@
             </div>
           </li>
           <li>
-            <div class="publication-title">Hybrid Neural Operators for Wireless Field Modeling</div>
+            <div class="publication-title">PU-HNO: Physics-Unrolled Hybrid Neural Operator for High-Fidelity Radio-Map Prediction</div>
             <div class="publication-meta">Submitted to NeurIPS 2026 — <strong>R. U. Murshed</strong> et al.</div>
             <p>
-              Develops specialized neural operators for object-centric wireless field modeling, targeting generalization across
-              environments and downstream integrated sensing-and-communication tasks.
+              Predicts high-fidelity indoor radio maps from low-fidelity ray-tracing outputs and scene priors through a
+              three-stage cascade that captures reflection, diffraction, and scattering effects, learning stable propagation
+              structure from noisy finite-ray labels.
             </p>
           </li>
           <li>

--- a/research.html
+++ b/research.html
@@ -82,8 +82,9 @@
           <article>
             <h3>Hybrid neural operators</h3>
             <p>
-              My NeurIPS 2026 submission explores neural operators for wireless field modeling, with an emphasis on scalable
-              object-centric generalization across spaces, layouts, and propagation conditions.
+              My NeurIPS 2026 submission introduces PU-HNO, a physics-unrolled hybrid neural operator that predicts
+              high-fidelity indoor radio maps from low-fidelity ray-tracing outputs and scene priors by progressively
+              modeling reflection, diffraction, and scattering effects.
             </p>
           </article>
           <article>
@@ -172,6 +173,7 @@
           <li><a href="https://elahe.web.illinois.edu/" target="_blank" rel="noopener">Prof. Elahe Soltanaghai (University of Illinois Urbana–Champaign)</a></li>
           <li><a href="https://www.utdallas.edu/~saquib/" target="_blank" rel="noopener">Prof. Mohammad Saquib (The University of Texas at Dallas)</a></li>
           <li><a href="https://aeroastro.mit.edu/people/moe-z-win/" target="_blank" rel="noopener">Prof. Moe Z. Win (Massachusetts Institute of Technology)</a></li>
+          <li><a href="https://publichealth.berkeley.edu/people/tierra-smiley-evans" target="_blank" rel="noopener">Prof. Tierra Smiley Evans (University of California, Berkeley)</a></li>
           <li><a href="https://www.sydney.edu.au/engineering/about/our-people/academic-staff/abbas-jamalipour.html" target="_blank" rel="noopener">Prof. Abbas Jamalipour (University of Sydney)</a></li>
           <li><a href="https://researchprofiles.canberra.edu.au/en/persons/kumudu-munasinghe" target="_blank" rel="noopener">Prof. Kumudu Munasinghe (University of Canberra)</a></li>
           <li><a href="https://researchprofiles.canberra.edu.au/en/persons/md-farhad-hossain" target="_blank" rel="noopener">Prof. Md Farhad Hossain (University of Canberra)</a></li>


### PR DESCRIPTION
### Motivation
- Clean up awkward metric wording and restore an expanded, linked biography layout that was shortened and columnized.  
- Replace an unclear EWSN metric with the requested h-index and update the NeurIPS submission text to match the supplied PU-HNO description.  
- Re-order and make the latest milestones month-specific and add the requested UC Berkeley collaborator to the collaborators list.

### Description
- Update homepage metric cards in `index.html` so GPA reads `4.0 out of 4.0` with label `Graduate GPA` and replace the EWSN metric with `6` / `h-index`.  
- Replace the two-column reduced bio with the provided stacked biography (preserving links to BUET, BUET-JIDPUS, UT Dallas, iSens Lab, advisors, etc.) by editing `index.html` and adding `.biography-text` layout rules to `css/main.css`.  
- Rewrite PU-HNO / NeurIPS descriptions on the homepage, research, and publications pages to the supplied radio-map prediction text by editing `index.html`, `research.html`, and `publications.html`.  
- Replace the homepage timeline with the exact chronological, month-specific entries requested and add `Prof. Tierra Smiley Evans` (UC Berkeley) to the collaborators list in `research.html`.

### Testing
- Ran targeted content checks with a small `python3` script to assert old awkward strings are gone, and the checks passed.  
- Parsed site HTML with `html.parser` to ensure pages remain valid, and the parser checks passed.  
- Ran `git diff --check` (no whitespace errors) and committed the updated files `index.html`, `research.html`, `publications.html`, and `css/main.css`.  
- Captured a full-page screenshot using `npx playwright` pointing to a local `python3 -m http.server` instance, and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb518240c8324b6bf38845a516011)